### PR TITLE
Configure backend env file for docker

### DIFF
--- a/first-aid-test/.gitignore
+++ b/first-aid-test/.gitignore
@@ -6,4 +6,5 @@ __pycache__/
 *.pyc
 # Env/OS
 .env
+!backend/.env
 .DS_Store

--- a/first-aid-test/backend/.env
+++ b/first-aid-test/backend/.env
@@ -1,0 +1,11 @@
+# Environment configuration for backend service
+# Populate these values with real credentials in deployment environments.
+OPENAI_API_KEY=changeme-openai
+GROQ_API_KEY=changeme-groq
+ASTRA_DB_API_ENDPOINT=https://example.com
+ASTRA_DB_KEYSPACE=first_aid
+ASTRA_DB_DATABASE=first_aid
+ASTRA_DB_COLLECTION=first_aid_vectors
+ASTRA_DB_APPLICATION_TOKEN=changeme-token
+MODEL_PREFERENCE=groq
+EMBEDDING_MODEL=text-embedding-3-small

--- a/first-aid-test/docker-compose.yml
+++ b/first-aid-test/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.9"
 services:
   backend:
     build: ./backend
+    env_file:
+      - ./backend/.env
     ports:
       - "8000:8000"
   frontend:


### PR DESCRIPTION
## Summary
- add a committed backend/.env file with placeholder values so the container build context exposes expected environment variables
- allow the committed backend env file to bypass the global .env ignore rule and load it through docker-compose
- configure the backend service in docker-compose to read variables from the env file

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68dced0b303c832ab0f724ef946723a8